### PR TITLE
relative path for catalog

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,12 @@
   "main": "src/main.js",
   "scripts": {
     "start": "vue-cli-service serve",
-    "build": "vue-cli-service build --HISTORY_MODE=hash",
-    "deploy:sit": "aws s3 sync ./dist s3://sit-stac.geoplatform.info --acl public-read --profile sit",
-    "deploy:stg": "aws s3 sync ./dist s3://stg-stac.geoplatform.gov --acl public-read --profile stg",
-    "deploy:prd": "echo aws s3 sync ./dist s3://stac.geoplatform.gov --acl public-read --profile prd"
+    "build:sit": "vue-cli-service build --CATALOG_URL=https://sit-stac.geoplatform.info/catalog.json --HISTORY_MODE=hash",
+    "build:stg": "vue-cli-service build --CATALOG_URL=https://stg-stac.geoplatform.gov/catalog.json --HISTORY_MODE=hash",
+    "build:prd": "vue-cli-service build --CATALOG_URL=https://stac.geoplatform.gov/catalog.json --HISTORY_MODE=hash",
+    "deploy:sit": "aws s3 sync ./dist s3://gp-sit-us-east-1-stac --acl public-read --profile sit",
+    "deploy:stg": "aws s3 sync ./dist s3://gp-stg-us-east-1-stac --acl public-read --profile stg",
+    "deploy:prd": "echo aws s3 sync ./dist s3://gp-stg-us-east-1-stac --acl public-read --profile prd"
   },
   "bugs": {
     "url": "https://github.com/radiantearth/stac-browser/issues"
@@ -31,13 +33,13 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "@babel/core": "^7.12.10",
-    "@radiantearth/stac-fields": "1.0.0-beta.7",
-    "@radiantearth/stac-migrate": "1.0.0",
+    "@babel/core": "^7.16.0",
+    "@radiantearth/stac-fields": "1.0.0-beta.10",
+    "@radiantearth/stac-migrate": "1.0.2",
     "bootstrap-vue": "^2.21.2",
     "bs58": "^4.0.1",
-    "commonmark": "^0.29.3",
-    "core-js": "^3.6.5",
+    "commonmark": "^0.30.0",
+    "core-js": "^3.19.1",
     "d3-scale-chromatic": "^1.5.0",
     "leaflet": "^1.7.1",
     "leaflet-easybutton": "^2.4.0",
@@ -51,17 +53,15 @@
     "vue-async-computed": "^3.9.0",
     "vue-meta": "^2.4.0",
     "vue-multiselect": "^2.1.6",
-    "vue-router": "^3.2.0",
+    "vue-router": "^3.5.3",
     "vuex": "^3.4.0",
     "yargs": "^17.0.1"
   },
   "devDependencies": {
-    "@vue/cli-plugin-babel": "~4.5.0",
-    "@vue/cli-plugin-router": "~4.5.0",
-    "@vue/cli-plugin-vuex": "~4.5.0",
-    "@vue/cli-service": "~4.5.0",
-    "serverless": "^2.64.1",
-    "serverless-s3-sync": "^1.17.2",
+    "@vue/cli-plugin-babel": "~4.5.15",
+    "@vue/cli-plugin-router": "~4.5.15",
+    "@vue/cli-plugin-vuex": "~4.5.15",
+    "@vue/cli-service": "~4.5.15",
     "vue-template-compiler": "^2.6.12"
   },
   "browserslist": [

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,4 @@
-export const BASE_CATALOG_URL = process.env.CATALOG_URL;
+export const BASE_CATALOG_URL =  window.location.href + "/catalog.json"
 export const TILE_SOURCE_TEMPLATE = process.env.TILE_SOURCE_TEMPLATE;
 export const STAC_PROXY_URL = process.env.STAC_PROXY_URL;
 export const TILE_PROXY_URL = process.env.TILE_PROXY_URL;

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,4 @@
-export const BASE_CATALOG_URL =  window.location.href + "/catalog.json"
+export const BASE_CATALOG_URL = process.env.CATALOG_URL;
 export const TILE_SOURCE_TEMPLATE = process.env.TILE_SOURCE_TEMPLATE;
 export const STAC_PROXY_URL = process.env.STAC_PROXY_URL;
 export const TILE_PROXY_URL = process.env.TILE_PROXY_URL;

--- a/vue.config.js
+++ b/vue.config.js
@@ -21,7 +21,7 @@ module.exports = {
 	publicPath: process.env.PATH_PREFIX || argv.PATH_PREFIX || DEFAULT_PATH_PREFIX, // Set this if you'd like to deploy at a sub-path,
 	chainWebpack: config => {
 	  	config.plugin('define').tap(args => {
-			args[0]["process.env"].CATALOG_URL = getVar('CATALOG_URL', 'http://gp-sit-us-east-1-stac.s3-website-us-east-1.amazonaws.com/catalog.json');
+			// args[0]["process.env"].CATALOG_URL = getVar('CATALOG_URL', 'http://gp-sit-us-east-1-stac.s3-website-us-east-1.amazonaws.com/catalog.json');
 			args[0]["process.env"].TILE_SOURCE_TEMPLATE = getVar('TILE_SOURCE_TEMPLATE', 'https://tiles.rdnt.io/tiles/{z}/{x}/{y}@2x?url={ASSET_HREF}');
 			args[0]["process.env"].STAC_PROXY_URL = getVar('STAC_PROXY_URL');
 			args[0]["process.env"].TILE_PROXY_URL = getVar('TILE_PROXY_URL');

--- a/vue.config.js
+++ b/vue.config.js
@@ -21,7 +21,7 @@ module.exports = {
 	publicPath: process.env.PATH_PREFIX || argv.PATH_PREFIX || DEFAULT_PATH_PREFIX, // Set this if you'd like to deploy at a sub-path,
 	chainWebpack: config => {
 	  	config.plugin('define').tap(args => {
-			// args[0]["process.env"].CATALOG_URL = getVar('CATALOG_URL', 'http://gp-sit-us-east-1-stac.s3-website-us-east-1.amazonaws.com/catalog.json');
+			args[0]["process.env"].CATALOG_URL = getVar('CATALOG_URL', 'https://stac.geoplatform.gov/catalog.json');
 			args[0]["process.env"].TILE_SOURCE_TEMPLATE = getVar('TILE_SOURCE_TEMPLATE', 'https://tiles.rdnt.io/tiles/{z}/{x}/{y}@2x?url={ASSET_HREF}');
 			args[0]["process.env"].STAC_PROXY_URL = getVar('STAC_PROXY_URL');
 			args[0]["process.env"].TILE_PROXY_URL = getVar('TILE_PROXY_URL');


### PR DESCRIPTION
Catalog is currently broken due to mixed content errors. This PR uses the relative path from STAC browser to find the default catalog.  